### PR TITLE
fix: restore consistent colors for highest rated tab

### DIFF
--- a/src/page.svelte
+++ b/src/page.svelte
@@ -1188,7 +1188,7 @@
                     ? ''
                     : 'hide'}"
             >
-                {#each [["genres", "genre", "rgb(72, 255, 132)"], ["countries", "country", "rgb(116, 240, 255)"], ["originallanguage", "language", "rgb(255, 184, 96)"]] as type}
+                {#each [["genres", "genre", "rgb(0, 224, 84)"], ["countries", "country", "rgb(64, 188, 244)"], ["originallanguage", "language", "rgb(255, 128, 0)"]] as type}
                     <div class="labels2">
                         {#each getValues(getSlice(data["tr_" + type[0]], 0, 10)) as element}
                             <div>


### PR DESCRIPTION
## Problem
The "Highest Rated" tab in the "Genres, Countries & Languages" section was using different colors than the "Most Watched" tab, causing visual inconsistency.

## Solution
Restored the Highest Rated section colors to match the original design and maintain consistency with the Most Watched section.

## Changes
- Updated the color palette for the 'Highest Rated' charts in page.svelte to match the 'Most Watched' section.
- Genres: `rgb(0, 224, 84)` - Green
- Countries: `rgb(64, 188, 244)` - Blue
- Languages: `rgb(255, 128, 0)` - Orange

## Testing
Tested by comparing both tabs visually to ensure color consistency.