### PR TITLE
fix: clarify page info text for genres section

### DIFF
--- a/src/page.svelte
+++ b/src/page.svelte
@@ -1224,7 +1224,7 @@
                     </div>
                 {/each}
                 <div class="infoavg">
-                    Themes and nanogenres with at least four rated films are
+                    Genres, countries and languages with at least four rated films are
                     included.
                 </div>
             </div>


### PR DESCRIPTION
## Problem
The "Genres, Countries & Languages" section copy references "Themes and nanogenres," which is misleading. The section actually displays data specifically categorized by genre, country, and language.

## Solution
Updated the informational copy to explicitly state that the section includes genres, countries, and languages with at least four rated films.

## Changes
File: [src/page.svelte](https://github.com/ErenTerakye/Statsboxd/blob/fix/page-info-text/src/page.svelte#L1226-L1229)
- Text update: "Genres, countries, and languages with at least four rated films are included."

## Testing
- This is a static text-only change.
- Verified the string update in [src/page.svelte](https://github.com/ErenTerakye/Statsboxd/blob/fix/page-info-text/src/page.svelte#L1226-L1229).