### PR TITLE
feat: add 'Films per decade' pie chart section

### DIFF
--- a/src/components/DecadePieChart.svelte
+++ b/src/components/DecadePieChart.svelte
@@ -1,0 +1,104 @@
+<script>
+    import Highcharts from "highcharts";
+    import "highcharts/modules/accessibility";
+
+    let { data } = $props();
+    let chartContainer = $state();
+
+    let chartInstance;
+    $effect(() => {
+        if (chartContainer && data && data.years) {
+            renderChart();
+        }
+        return () => chartInstance?.destroy();
+    });
+
+    function getDecadeData() {
+        const buckets = {};
+        (data.years || []).forEach((y) => {
+            const decade = Math.floor(y._id / 10) * 10;
+            buckets[decade] = (buckets[decade] || 0) + (y.sum || 0);
+        });
+        return Object.keys(buckets)
+            .sort((a, b) => Number(a) - Number(b))
+            .map((d) => ({ name: d + "s", y: buckets[d] }));
+    }
+
+    function renderChart() {
+        const seriesData = getDecadeData();
+
+        chartInstance?.destroy();
+        chartInstance = Highcharts.chart(chartContainer, {
+            chart: {
+                type: "pie",
+                backgroundColor: "transparent",
+            },
+            title: { text: null },
+            credits: { enabled: false },
+            tooltip: {
+                pointFormat:
+                    "<b>{point.name}</b>: {point.y} films ({point.percentage:.1f}%)",
+            },
+            plotOptions: {
+                pie: {
+                    cursor: "pointer",
+                    innerSize: "45%",
+                    borderWidth: 1,
+                    borderColor: "#14181c",
+                    point: {
+                        events: {
+                            click: function () {
+                                const decade = this.name.replace(/s$/, "");
+                                window.open("https://letterboxd.com/" + data.username + "/films/decade/" + decade + "s/","_blank");
+                            },
+                        },
+                    },
+                    dataLabels: {
+                        enabled: true,
+                        format: "<b>{point.name}</b><br>{point.percentage:.0f}%",
+                        style: {
+                            color: "#def",
+                            fontFamily: "Graphik-Light-Web, sans-serif",
+                            fontWeight: "400",
+                            textOutline: "none",
+                            fontSize: "12px",
+                        },
+                        connectorColor: "#556",
+                        distance: 20,
+                    },
+                },
+            },
+            series: [
+                {
+                    name: "Films",
+                    colorByPoint: true,
+                    data: seriesData,
+                    colors: [
+                        "#00e054",
+                        "#12d669",
+                        "#24cc7e",
+                        "#36c293",
+                        "#48b8a8",
+                        "#5aaebd",
+                        "#6ca4d2",
+                        "#3fbcf2",
+                        "#5ca9e8",
+                        "#7996de",
+                        "#9683d4",
+                        "#b370ca",
+                        "#d05dc0",
+                    ],
+                },
+            ],
+        });
+    }
+</script>
+
+<div class="decadePieChart" bind:this={chartContainer}></div>
+
+<style>
+    .decadePieChart {
+        width: 100%;
+        height: 320px;
+    }
+</style>

--- a/src/page.svelte
+++ b/src/page.svelte
@@ -27,6 +27,7 @@
     import DayOfWeekChart from "./components/DayOfWeekChart.svelte";
     import PieChartsSection from "./components/PieChartsSection.svelte";
     import RatingSpreadChart from "./components/RatingSpreadChart.svelte";
+    import DecadePieChart from "./components/DecadePieChart.svelte";
 
     let { data, year, yearnum } = $props();
 
@@ -914,6 +915,15 @@
                 </div>
             {/if}
         </section>
+        {#if data.ru && data.years}
+            <section class="sectionStats">
+                <div class="sepline">
+                    <span>Films per decade</span>
+                    <div class="line"></div>
+                </div>
+                <DecadePieChart {data} />
+            </section>
+        {/if}
         {#if data.ru}
             <section class="sectionStats">
                 <div class="sepline">


### PR DESCRIPTION
Small feature idea I thought would be a neat addition.

Added a "Films per decade" section containing a pie chart that shows the number of movies watched from each decade and the percentage of the total for each one. Clicking a slice opens the corresponding decade's filtered page on Letterboxd in a new tab.

The decade breakdown is computed client-side by bucketing data.years into 10-year groups, so no backend changes are required.

## Screenshots
<img width="992" height="437" alt="Screenshot 2026-04-08 at 13 35 54" src="https://github.com/user-attachments/assets/b7d93169-a93b-4a8a-9b38-779d04d0e6c2" />
<img width="992" height="437" alt="Screenshot 2026-04-08 at 13 36 08" src="https://github.com/user-attachments/assets/164e081e-acee-49a9-b2ab-16280a71951e" />

