### PR TITLE
fix: resolved unresponsive Ratings tab in ReleaseYearChart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "statsboxd-svelte",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "statsboxd-svelte",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@tensorflow/tfjs": "^4.22.0",
         "abort-controller": "^3.0.0",

--- a/src/components/ReleaseYearChart.svelte
+++ b/src/components/ReleaseYearChart.svelte
@@ -32,7 +32,7 @@
                 return `<div class="ttYear"><span class="ttTitle">${this.y - 1} films</span><span class="ttSubtitle">Year ${this.points[0].key}</span></div>`;
             };
         } else if (activeType === "ratingYear") {
-            statsData = data.ru.map((element) => ({
+            statsData = data.years.map((element) => ({
                 name: element["_id"],
                 y: element["avg"] + 1,
             }));


### PR DESCRIPTION
### Problem
Clicking the "RATINGS" tab on the page alonside FILMS and DIARY fails to render the chart, even though the other two are working. The live console throws the following error:
`Uncaught TypeError: e().ru.map is not a function`

### Solution
The `ReleaseYearChart.svelte` component was attempting to run `.map()` on `data.ru` (which acts as a boolean flag). I updated the `ratingYear` block to correctly map over the `data.years` array instead, targeting `element["avg"]`.

*(Note: I couldn't fully verify the chart render locally as I don't have the `.env` backend/TMDB keys to process the zip file, but the console stack trace points directly to this mapping typo, so hopefully I helped in some way).*